### PR TITLE
Handle empty search results gracefully

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -23,9 +23,8 @@ export default function App() {
 
   const [fromKm, setFromKm] = useState(0)
   const [toKm, setToKm] = useState(10)
-  const [scale, setScale] = useState(0.1)
 
-  const [bands, setBands] = useState(() => DEFAULT_BANDS)
+  const bands = DEFAULT_BANDS
   const domain = useMemo(() => ({ fromKm, toKm }), [fromKm, toKm])
 
   useEffect(() => {
@@ -52,7 +51,7 @@ export default function App() {
   const onSearch = async () => {
     const r = await fetchRoads(q)
     setRoads(r)
-    if (r.length) setRoad(r[0])
+    setRoad(r[0] || null)
   }
 
   // ✅ Forward the optional extras (like { edge: 'start' } for bridges)
@@ -90,8 +89,6 @@ export default function App() {
           road={road}
           domain={domain}
           onDomainChange={(a,b)=>{ setFromKm(a); setToKm(b) }}
-          scale={scale}
-          setScale={setScale}
         />
 
         <SLDCanvasV2
@@ -101,7 +98,6 @@ export default function App() {
           domain={domain}
           onDomainChange={(a,b)=>{ setFromKm(a); setToKm(b) }}
           bands={bands}
-          onBandsChange={setBands}
           onMoveSeam={handleMoveSeam}
         />
       </div>

--- a/client/src/components/ControlBar.jsx
+++ b/client/src/components/ControlBar.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 
-export default function ControlBar({ road, domain, onDomainChange, scale, setScale }) {
+export default function ControlBar({ road, domain, onDomainChange }) {
   const lengthKm = Number(road?.lengthKm || 0)
   const from = domain?.fromKm ?? 0
   const to   = domain?.toKm ?? Math.max(10, lengthKm)

--- a/client/src/components/SLDCanvasV2.jsx
+++ b/client/src/components/SLDCanvasV2.jsx
@@ -28,7 +28,6 @@ export default function SLDCanvasV2({
   domain,
   onDomainChange,
   bands,
-  onBandsChange,
   onMoveSeam,        // (bandKey, leftId, rightId, km, extra={})
 }) {
   const canvasRef = useRef(null)
@@ -194,7 +193,7 @@ export default function SLDCanvasV2({
           drawRanges(box, layers?.surface, r => SURFACE_COLORS[r.surface]||'#bdbdbd', r => r.surface)
           break
         case 'aadt':
-          drawRanges(box, layers?.aadt, _ => '#6a1b9a', r => formatAADT(r.aadt))
+          drawRanges(box, layers?.aadt, () => '#6a1b9a', r => formatAADT(r.aadt))
           break
         case 'status':
           drawRanges(box, layers?.status, r => STATUS_COLORS[r.status]||'#bdbdbd', r => r.status)
@@ -203,16 +202,16 @@ export default function SLDCanvasV2({
           drawRanges(box, layers?.quality, r => QUALITY_COLORS[r.quality]||'#bdbdbd', r => r.quality)
           break
         case 'rowWidth':
-          drawRanges(box, layers?.rowWidth, _ => '#1565c0', r => `${r.rowWidthM} m`)
+          drawRanges(box, layers?.rowWidth, () => '#1565c0', r => `${r.rowWidthM} m`)
           break
         case 'lanes':
-          drawRanges(box, layers?.lanes, _ => '#4e342e', r => `${r.lanes} lanes`)
+          drawRanges(box, layers?.lanes, () => '#4e342e', r => `${r.lanes} lanes`)
           break
         case 'municipality':
-          drawRanges(box, layers?.municipality, _ => '#00796b', r => r.name)
+          drawRanges(box, layers?.municipality, () => '#00796b', r => r.name)
           break
         case 'bridges':
-          drawRanges(box, layers?.bridges, _ => '#5d4037', r => r.name)
+          drawRanges(box, layers?.bridges, () => '#5d4037', r => r.name)
           break
         default:
           break


### PR DESCRIPTION
## Summary
- Clear selected road when a search yields no matches to avoid showing stale data
- Remove unused props and parameters from client components to satisfy lint

## Testing
- `npm test` (fails: Missing script "test")
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a46fc378e48323b7855efe361db3e8