### PR TITLE
Show 100m ticks at ≤2km span

### DIFF
--- a/client/src/components/SLDCanvasV2.jsx
+++ b/client/src/components/SLDCanvasV2.jsx
@@ -190,9 +190,9 @@ export default function SLDCanvasV2({
     ctx.lineWidth = 1
       const minPost = Math.ceil(fromKm)
       const maxPost = Math.floor(toKm)
-      const postCount = maxPost >= minPost ? (maxPost - minPost + 1) : 0
-      // show 100m ticks only at high zoom and when two or fewer KM posts are visible
-      const showHundred = zoom >= 80 && zoom < 160 && postCount <= 2
+      const spanKm = toKm - fromKm
+      // show 100m ticks when viewing 2 km or less of road
+      const showHundred = spanKm <= 2
       const step = showHundred ? 0.1 : 1
       const startTick = Math.ceil(fromKm / step) * step
       ctx.textAlign = 'center'


### PR DESCRIPTION
## Summary
- switch axis tick logic to use visible span
- display 100m interval ticks when viewing 2 km or less

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4af7dac8c8323aa406e80fce487ad