### PR TITLE
feat: add chainage model for irregular km posts

### DIFF
--- a/server/prisma/migrations/20250817160000_add_chainage_table/migration.sql
+++ b/server/prisma/migrations/20250817160000_add_chainage_table/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "Chainage" (
+    "id" SERIAL PRIMARY KEY,
+    "section_id" INTEGER NOT NULL,
+    "km_post_id" INTEGER NOT NULL,
+    "chainage" DOUBLE PRECISION NOT NULL,
+    "lrp" TEXT NOT NULL,
+    CONSTRAINT "Chainage_section_id_fkey" FOREIGN KEY ("section_id") REFERENCES "Segment"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Chainage_km_post_id_fkey" FOREIGN KEY ("km_post_id") REFERENCES "KmPost"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "Chainage_section_km_chainage_idx" ON "Chainage"("section_id", "km_post_id", "chainage");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -31,18 +31,19 @@ model Road {
 }
 
 model Segment {
-  id         Int      @id @default(autoincrement())
-  roadId     Int
-  startKm    Float
-  endKm      Float
-  surface    String?
-  lanesLeft  Int?
-  lanesRight Int?
-  status     String?
-  quality    String?
-  road       Road     @relation(fields: [roadId], references: [id])
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+    id         Int      @id @default(autoincrement())
+    roadId     Int
+    startKm    Float
+    endKm      Float
+    surface    String?
+    lanesLeft  Int?
+    lanesRight Int?
+    status     String?
+    quality    String?
+    road       Road     @relation(fields: [roadId], references: [id])
+    chainages  Chainage[]
+    createdAt  DateTime @default(now())
+    updatedAt  DateTime @updatedAt
 
   @@index([roadId, startKm, endKm])
 }
@@ -152,6 +153,19 @@ model KmPost {
   km     Float
   label  String?
   road   Road    @relation(fields: [roadId], references: [id])
+  chainages Chainage[]
 
   @@index([roadId, km])
+}
+
+model Chainage {
+  id        Int     @id @default(autoincrement())
+  sectionId Int     @map("section_id")
+  kmPostId  Int     @map("km_post_id")
+  chainage  Float
+  lrp       String
+  section   Segment @relation(fields: [sectionId], references: [id])
+  kmPost    KmPost  @relation(fields: [kmPostId], references: [id])
+
+  @@index([sectionId, kmPostId, chainage])
 }


### PR DESCRIPTION
## Summary
- add Chainage model to track chainage between kilometer posts
- create migration for Chainage table and index

## Testing
- `npm run prisma:generate`


------
https://chatgpt.com/codex/tasks/task_e_68a6fa2361d0832383d827809343e04f