### PR TITLE
Use meters and add road sections

### DIFF
--- a/server/prisma/migrations/20250817170000_switch_to_meters/migration.sql
+++ b/server/prisma/migrations/20250817170000_switch_to_meters/migration.sql
@@ -1,0 +1,53 @@
+-- Switch measurement units to meters and add Section table
+
+ALTER TABLE "Road" RENAME COLUMN "lengthKm" TO "lengthM";
+
+ALTER TABLE "Segment" RENAME COLUMN "startKm" TO "startM";
+ALTER TABLE "Segment" RENAME COLUMN "endKm" TO "endM";
+ALTER INDEX "Segment_roadId_startKm_endKm_idx" RENAME TO "Segment_roadId_startM_endM_idx";
+
+CREATE TABLE "Section" (
+    "id" SERIAL PRIMARY KEY,
+    "roadId" INTEGER NOT NULL,
+    "startM" DOUBLE PRECISION NOT NULL,
+    "endM" DOUBLE PRECISION NOT NULL,
+    "createdAt" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Section_roadId_fkey" FOREIGN KEY ("roadId") REFERENCES "Road"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+CREATE INDEX "Section_roadId_startM_endM_idx" ON "Section"("roadId", "startM", "endM");
+
+ALTER TABLE "SurfaceBand" RENAME COLUMN "startKm" TO "startM";
+ALTER TABLE "SurfaceBand" RENAME COLUMN "endKm" TO "endM";
+ALTER INDEX "SurfaceBand_roadId_startKm_endKm_idx" RENAME TO "SurfaceBand_roadId_startM_endM_idx";
+
+ALTER TABLE "AadtBand" RENAME COLUMN "startKm" TO "startM";
+ALTER TABLE "AadtBand" RENAME COLUMN "endKm" TO "endM";
+ALTER INDEX "AadtBand_roadId_startKm_endKm_idx" RENAME TO "AadtBand_roadId_startM_endM_idx";
+
+ALTER TABLE "StatusBand" RENAME COLUMN "startKm" TO "startM";
+ALTER TABLE "StatusBand" RENAME COLUMN "endKm" TO "endM";
+ALTER INDEX "StatusBand_roadId_startKm_endKm_idx" RENAME TO "StatusBand_roadId_startM_endM_idx";
+
+ALTER TABLE "QualityBand" RENAME COLUMN "startKm" TO "startM";
+ALTER TABLE "QualityBand" RENAME COLUMN "endKm" TO "endM";
+ALTER INDEX "QualityBand_roadId_startKm_endKm_idx" RENAME TO "QualityBand_roadId_startM_endM_idx";
+
+ALTER TABLE "LanesBand" RENAME COLUMN "startKm" TO "startM";
+ALTER TABLE "LanesBand" RENAME COLUMN "endKm" TO "endM";
+ALTER INDEX "LanesBand_roadId_startKm_endKm_idx" RENAME TO "LanesBand_roadId_startM_endM_idx";
+
+ALTER TABLE "RowWidthBand" RENAME COLUMN "startKm" TO "startM";
+ALTER TABLE "RowWidthBand" RENAME COLUMN "endKm" TO "endM";
+ALTER INDEX "RowWidthBand_roadId_startKm_endKm_idx" RENAME TO "RowWidthBand_roadId_startM_endM_idx";
+
+ALTER TABLE "MunicipalityBand" RENAME COLUMN "startKm" TO "startM";
+ALTER TABLE "MunicipalityBand" RENAME COLUMN "endKm" TO "endM";
+ALTER INDEX "MunicipalityBand_roadId_startKm_endKm_idx" RENAME TO "MunicipalityBand_roadId_startM_endM_idx";
+
+ALTER TABLE "BridgeBand" RENAME COLUMN "startKm" TO "startM";
+ALTER TABLE "BridgeBand" RENAME COLUMN "endKm" TO "endM";
+ALTER INDEX "BridgeBand_roadId_startKm_endKm_idx" RENAME TO "BridgeBand_roadId_startM_endM_idx";
+
+ALTER TABLE "KmPost" RENAME COLUMN "chainage" TO "chainageM";
+ALTER INDEX "KmPost_road_chainage_idx" RENAME TO "KmPost_road_chainageM_idx";

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -12,10 +12,11 @@ datasource db {
 model Road {
   id       Int    @id @default(autoincrement())
   name     String
-  lengthKm Float
+  lengthM  Float
 
   // back-relations (required so Prisma is happy)
   segments          Segment[]
+  sections          Section[]
   surfaceBands      SurfaceBand[]
   aadtBands         AadtBand[]
   statusBands       StatusBand[]
@@ -33,8 +34,8 @@ model Road {
 model Segment {
     id         Int      @id @default(autoincrement())
     roadId     Int
-    startKm    Float
-    endKm      Float
+    startM     Float
+    endM       Float
     surface    String?
     lanesLeft  Int?
     lanesRight Int?
@@ -44,7 +45,19 @@ model Segment {
     createdAt  DateTime @default(now())
     updatedAt  DateTime @updatedAt
 
-  @@index([roadId, startKm, endKm])
+  @@index([roadId, startM, endM])
+}
+
+model Section {
+  id       Int      @id @default(autoincrement())
+  roadId   Int
+  startM   Float
+  endM     Float
+  road     Road     @relation(fields: [roadId], references: [id])
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([roadId, startM, endM])
 }
 
 // ---- Per-band range tables --------------------------------------------------
@@ -52,45 +65,45 @@ model Segment {
 model SurfaceBand {
   id      Int    @id @default(autoincrement())
   roadId  Int
-  startKm Float
-  endKm   Float
+  startM  Float
+  endM    Float
   surface String
   road    Road   @relation(fields: [roadId], references: [id])
 
-  @@index([roadId, startKm, endKm])
+  @@index([roadId, startM, endM])
 }
 
 model AadtBand {
   id      Int   @id @default(autoincrement())
   roadId  Int
-  startKm Float
-  endKm   Float
+  startM  Float
+  endM    Float
   aadt    Int
   road    Road  @relation(fields: [roadId], references: [id])
 
-  @@index([roadId, startKm, endKm])
+  @@index([roadId, startM, endM])
 }
 
 model StatusBand {
   id      Int    @id @default(autoincrement())
   roadId  Int
-  startKm Float
-  endKm   Float
+  startM  Float
+  endM    Float
   status  String
   road    Road   @relation(fields: [roadId], references: [id])
 
-  @@index([roadId, startKm, endKm])
+  @@index([roadId, startM, endM])
 }
 
 model QualityBand {
   id      Int    @id @default(autoincrement())
   roadId  Int
-  startKm Float
-  endKm   Float
+  startM  Float
+  endM    Float
   quality String
   road    Road   @relation(fields: [roadId], references: [id])
 
-  @@index([roadId, startKm, endKm])
+  @@index([roadId, startM, endM])
 }
 
 // Which side gets the extra lane when LanesBand.lanes is odd
@@ -102,56 +115,56 @@ enum SideBias {
 model LanesBand {
   id       Int      @id @default(autoincrement())
   roadId   Int
-  startKm  Float
-  endKm    Float
+  startM   Float
+  endM     Float
   lanes    Int
   sideBias SideBias @default(TOP)
   road     Road     @relation(fields: [roadId], references: [id])
 
-  @@index([roadId, startKm, endKm])
+  @@index([roadId, startM, endM])
 }
 
 model RowWidthBand {
   id        Int   @id @default(autoincrement())
   roadId    Int
-  startKm   Float
-  endKm     Float
+  startM    Float
+  endM      Float
   rowWidthM Int
   road      Road  @relation(fields: [roadId], references: [id])
 
-  @@index([roadId, startKm, endKm])
+  @@index([roadId, startM, endM])
 }
 
 model MunicipalityBand {
   id      Int    @id @default(autoincrement())
   roadId  Int
-  startKm Float
-  endKm   Float
+  startM  Float
+  endM    Float
   name    String
   road    Road   @relation(fields: [roadId], references: [id])
 
-  @@index([roadId, startKm, endKm])
+  @@index([roadId, startM, endM])
 }
 
 model BridgeBand {
   id      Int    @id @default(autoincrement())
   roadId  Int
-  startKm Float
-  endKm   Float
+  startM  Float
+  endM    Float
   name    String
   road    Road   @relation(fields: [roadId], references: [id])
 
-  @@index([roadId, startKm, endKm])
+  @@index([roadId, startM, endM])
 }
 
 // ---- Point events -----------------------------------------------------------
 
 model KmPost {
-  id       Int     @id @default(autoincrement())
-  roadId   Int     @map("section_id")
-  chainage Float
-  lrp      String
-  road     Road    @relation(fields: [roadId], references: [id])
+  id        Int     @id @default(autoincrement())
+  roadId    Int     @map("section_id")
+  chainageM Float
+  lrp       String
+  road      Road    @relation(fields: [roadId], references: [id])
 
-  @@index([roadId, chainage])
+  @@index([roadId, chainageM])
 }

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -7,84 +7,91 @@ async function seedForRoad(road) {
 
   // Legacy segments (optional, keeps the lane diagram fallback alive)
   const segments = [
-    { startKm: 0.0,  endKm: 4.0,  lanesLeft: 1, lanesRight: 1, surface: 'Asphalt',  status:'Open',  quality:'Good',      sidewalk:true,  aadt: 18000 },
-    { startKm: 4.0,  endKm: 8.0,  lanesLeft: 1, lanesRight: 1, surface: 'Concrete', status:'Open',  quality:'Fair',      sidewalk:false, aadt: 26500 },
-    { startKm: 8.0,  endKm:12.5,  lanesLeft: 2, lanesRight: 1, surface: 'Concrete', status:'Open',  quality:'Fair',      sidewalk:false, aadt: 28000 },
-    { startKm:12.5,  endKm:20.0,  lanesLeft: 2, lanesRight: 2, surface: 'Asphalt',  status:'Closed',quality:'Excellent', sidewalk:true,  aadt: 31000 },
+    { startM:    0,  endM:  4000, lanesLeft: 1, lanesRight: 1, surface: 'Asphalt',  status:'Open',  quality:'Good',      sidewalk:true,  aadt: 18000 },
+    { startM: 4000,  endM:  8000, lanesLeft: 1, lanesRight: 1, surface: 'Concrete', status:'Open',  quality:'Fair',      sidewalk:false, aadt: 26500 },
+    { startM: 8000,  endM: 12500, lanesLeft: 2, lanesRight: 1, surface: 'Concrete', status:'Open',  quality:'Fair',      sidewalk:false, aadt: 28000 },
+    { startM:12500,  endM: 20000, lanesLeft: 2, lanesRight: 2, surface: 'Asphalt',  status:'Closed',quality:'Excellent', sidewalk:true,  aadt: 31000 },
   ]
   for (const s of segments) await prisma.segment.create({ data: { roadId: rid, ...s } })
+
+  await prisma.section.createMany({
+    data: [
+      { roadId: rid, startM:    0, endM: 10000 },
+      { roadId: rid, startM:10000, endM: 20000 },
+    ]
+  })
 
   // Independent range bands
   await prisma.surfaceBand.createMany({
     data: [
-      { roadId: rid, startKm: 0.0,  endKm: 6.0,  surface: 'Asphalt'  },
-      { roadId: rid, startKm: 6.0,  endKm: 12.0, surface: 'Concrete' },
-      { roadId: rid, startKm: 12.0, endKm: 20.0, surface: 'Gravel'   },
+      { roadId: rid, startM:    0, endM:  6000, surface: 'Asphalt'  },
+      { roadId: rid, startM: 6000, endM: 12000, surface: 'Concrete' },
+      { roadId: rid, startM:12000, endM: 20000, surface: 'Gravel'   },
     ]
   })
 
   await prisma.aadtBand.createMany({
     data: [
-      { roadId: rid, startKm: 0.0,  endKm: 5.0,  aadt: 16000 },
-      { roadId: rid, startKm: 5.0,  endKm: 12.0, aadt: 27000 },
-      { roadId: rid, startKm: 12.0, endKm: 20.0, aadt: 32000 },
+      { roadId: rid, startM:    0, endM:  5000, aadt: 16000 },
+      { roadId: rid, startM: 5000, endM: 12000, aadt: 27000 },
+      { roadId: rid, startM:12000, endM: 20000, aadt: 32000 },
     ]
   })
 
   await prisma.statusBand.createMany({
     data: [
-      { roadId: rid, startKm: 0.0,  endKm: 14.0, status: 'Open'   },
-      { roadId: rid, startKm: 14.0, endKm: 20.0, status: 'Closed' },
+      { roadId: rid, startM:    0, endM: 14000, status: 'Open'   },
+      { roadId: rid, startM:14000, endM: 20000, status: 'Closed' },
     ]
   })
 
   await prisma.qualityBand.createMany({
     data: [
-      { roadId: rid, startKm: 0.0,  endKm: 4.0,  quality: 'Good'      },
-      { roadId: rid, startKm: 4.0,  endKm: 10.0, quality: 'Fair'      },
-      { roadId: rid, startKm: 10.0, endKm: 20.0, quality: 'Excellent' },
+      { roadId: rid, startM:    0, endM:  4000, quality: 'Good'      },
+      { roadId: rid, startM: 4000, endM: 10000, quality: 'Fair'      },
+      { roadId: rid, startM:10000, endM: 20000, quality: 'Excellent' },
     ]
   })
 
   await prisma.lanesBand.createMany({
     data: [
-      { roadId: rid, startKm: 0.0,  endKm: 6.0,  lanes: 2 },
-      { roadId: rid, startKm: 6.0,  endKm: 12.0, lanes: 3 },
-      { roadId: rid, startKm: 12.0, endKm: 20.0, lanes: 4 },
+      { roadId: rid, startM:    0, endM:  6000, lanes: 2 },
+      { roadId: rid, startM: 6000, endM: 12000, lanes: 3 },
+      { roadId: rid, startM:12000, endM: 20000, lanes: 4 },
     ]
   })
 
   await prisma.rowWidthBand.createMany({
     data: [
-      { roadId: rid, startKm: 0.0,  endKm: 8.0,  rowWidthM: 20 },
-      { roadId: rid, startKm: 8.0,  endKm: 20.0, rowWidthM: 30 },
+      { roadId: rid, startM:    0, endM:  8000, rowWidthM: 20 },
+      { roadId: rid, startM: 8000, endM: 20000, rowWidthM: 30 },
     ]
   })
 
   await prisma.municipalityBand.createMany({
     data: [
-      { roadId: rid, startKm: 0.0,  endKm: 7.5,  name: 'San Isidro'     },
-      { roadId: rid, startKm: 7.5,  endKm: 14.0, name: 'Sta. Maria'     },
-      { roadId: rid, startKm: 14.0, endKm: 20.0, name: 'San Rafael'     },
+      { roadId: rid, startM:    0, endM:  7500, name: 'San Isidro'     },
+      { roadId: rid, startM: 7500, endM: 14000, name: 'Sta. Maria'     },
+      { roadId: rid, startM:14000, endM: 20000, name: 'San Rafael'     },
     ]
   })
 
   await prisma.bridgeBand.createMany({
     data: [
-      { roadId: rid, startKm: 3.2,  endKm: 3.5,  name: 'Mabini Bridge'  },
-      { roadId: rid, startKm: 11.0, endKm: 11.2, name: 'Carmelita Br.'  },
+      { roadId: rid, startM:  3200, endM:  3500, name: 'Mabini Bridge'  },
+      { roadId: rid, startM: 11000, endM: 11200, name: 'Carmelita Br.'  },
     ]
   })
 
   await prisma.kmPost.createMany({
     data: [
-      { roadId: rid, km: 0.0,  label: 'KM 0'  },
-      { roadId: rid, km: 1.0,  label: 'KM 1'  },
-      { roadId: rid, km: 2.0,  label: 'KM 2'  },
-      { roadId: rid, km: 5.0,  label: 'KM 5'  },
-      { roadId: rid, km: 10.0, label: 'KM 10' },
-      { roadId: rid, km: 15.0, label: 'KM 15' },
-      { roadId: rid, km: 20.0, label: 'KM 20' },
+      { roadId: rid, chainageM:    0, lrp: 'KM 0'  },
+      { roadId: rid, chainageM: 1000, lrp: 'KM 1'  },
+      { roadId: rid, chainageM: 2000, lrp: 'KM 2'  },
+      { roadId: rid, chainageM: 5000, lrp: 'KM 5'  },
+      { roadId: rid, chainageM:10000, lrp: 'KM 10' },
+      { roadId: rid, chainageM:15000, lrp: 'KM 15' },
+      { roadId: rid, chainageM:20000, lrp: 'KM 20' },
     ]
   })
 }
@@ -92,7 +99,7 @@ async function seedForRoad(road) {
 async function main() {
   let road = await prisma.road.findFirst()
   if (!road) {
-    road = await prisma.road.create({ data: { name: 'NH-12 Demo Corridor', lengthKm: 20 } })
+    road = await prisma.road.create({ data: { name: 'NH-12 Demo Corridor', lengthM: 20000 } })
     await seedForRoad(road)
     console.log('🌱 Seeded NH-12 with independent bands + km posts')
   } else {

--- a/server/server.js
+++ b/server/server.js
@@ -11,7 +11,7 @@ app.use(cors())
 app.use(bodyParser.json())
 
 const PORT = process.env.PORT || 4000
-const EPS = 1e-6
+const EPS = 1e-3
 const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v)) // used for non-bridge bands
 
 // ---------- helpers ----------
@@ -51,7 +51,7 @@ app.get('/api/roads/:id/segments', async (req, res) => {
   if (!road) return res.status(404).json({ error: 'Road not found' })
   const segments = await prisma.segment.findMany({
     where: { roadId },
-    orderBy: [{ startKm:'asc' }, { id:'asc' }],
+    orderBy: [{ startM:'asc' }, { id:'asc' }],
   })
   res.json({ road, segments })
 })
@@ -65,15 +65,15 @@ app.get('/api/roads/:id/layers', async (req, res) => {
   const [
     surface, aadt, status, quality, lanes, rowWidth, municipality, bridges, kmPosts
   ] = await Promise.all([
-    prisma.surfaceBand.findMany({ where: { roadId }, orderBy: [{ startKm:'asc' }, { id:'asc' }] }),
-    prisma.aadtBand.findMany({ where: { roadId }, orderBy: [{ startKm:'asc' }, { id:'asc' }] }),
-    prisma.statusBand.findMany({ where: { roadId }, orderBy: [{ startKm:'asc' }, { id:'asc' }] }),
-    prisma.qualityBand.findMany({ where: { roadId }, orderBy: [{ startKm:'asc' }, { id:'asc' }] }),
-    prisma.lanesBand.findMany({ where: { roadId }, orderBy: [{ startKm:'asc' }, { id:'asc' }] }),
-    prisma.rowWidthBand.findMany({ where: { roadId }, orderBy: [{ startKm:'asc' }, { id:'asc' }] }),
-    prisma.municipalityBand.findMany({ where: { roadId }, orderBy: [{ startKm:'asc' }, { id:'asc' }] }),
-    prisma.bridgeBand.findMany({ where: { roadId }, orderBy: [{ startKm:'asc' }, { id:'asc' }] }),
-    prisma.kmPost.findMany({ where: { roadId }, orderBy: [{ km:'asc' }, { id:'asc' }] }),
+    prisma.surfaceBand.findMany({ where: { roadId }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.aadtBand.findMany({ where: { roadId }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.statusBand.findMany({ where: { roadId }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.qualityBand.findMany({ where: { roadId }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.lanesBand.findMany({ where: { roadId }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.rowWidthBand.findMany({ where: { roadId }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.municipalityBand.findMany({ where: { roadId }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.bridgeBand.findMany({ where: { roadId }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.kmPost.findMany({ where: { roadId }, orderBy: [{ chainageM:'asc' }, { id:'asc' }] }),
   ])
 
   res.json({ road, surface, aadt, status, quality, lanes, rowWidth, municipality, bridges, kmPosts })
@@ -83,13 +83,13 @@ app.get('/api/roads/:id/layers', async (req, res) => {
  * Generic seam move:
  * - Default bands (non-bridges): keep gap-free by tying both sides to the same seam (clamped between neighbors).
  * - Bridges: NO snapping/clamping to neighbors or road ends. We only ensure the row stays valid:
- *       edge='end'   -> endKm = km (but minimally > startKm)
- *       edge='start' -> startKm = km (but minimally < endKm)
+ *       edge='end'   -> endM = m (but minimally > startM)
+ *       edge='start' -> startM = m (but minimally < endM)
  *
  * POST /api/roads/:id/bands/:band/move-seam
  * body:
- *   non-bridges: { leftId:number, rightId:number, km:number }
- *   bridges:     { leftId?:number, rightId?:number, km:number, edge:'start'|'end' }
+ *   non-bridges: { leftId:number, rightId:number, m:number }
+ *   bridges:     { leftId?:number, rightId?:number, m:number, edge:'start'|'end' }
  */
 app.post('/api/roads/:id/bands/:band/move-seam', async (req, res) => {
   const roadId = Number(req.params.id)
@@ -100,8 +100,8 @@ app.post('/api/roads/:id/bands/:band/move-seam', async (req, res) => {
   const road = await prisma.road.findUnique({ where: { id: roadId } })
   if (!road) return res.status(404).json({ error: 'Road not found' })
 
-  const { leftId, rightId, km, edge } = req.body || {}
-  if (!Number.isFinite(km)) return res.status(400).json({ error: 'km is required' })
+  const { leftId, rightId, m, edge } = req.body || {}
+  if (!Number.isFinite(m)) return res.status(400).json({ error: 'm is required' })
 
   try {
     const rows = await prisma.$transaction(async (tx) => {
@@ -114,22 +114,22 @@ app.post('/api/roads/:id/bands/:band/move-seam', async (req, res) => {
           const left = await T.findUnique({ where: { id: leftId } })
           if (!left || left.roadId !== roadId) throw new Error('left row missing/mismatch')
 
-          // keep row valid (end > start) with minimal epsilon; otherwise use raw km
-          let newKm = km
-          if (!(newKm > left.startKm + EPS)) newKm = left.startKm + 0.0001
-          await T.update({ where: { id: left.id }, data: { endKm: newKm } })
+          // keep row valid (end > start) with minimal epsilon; otherwise use raw m
+          let newM = m
+          if (!(newM > left.startM + EPS)) newM = left.startM + 0.1
+          await T.update({ where: { id: left.id }, data: { endM: newM } })
 
           // Optional: merge with left neighbor if identical value and contiguous
           const leftNeighbor = await T.findFirst({
-            where: { roadId, endKm: { gte: left.startKm - EPS, lte: left.startKm + EPS } },
-            orderBy: { endKm: 'desc' }
+            where: { roadId, endM: { gte: left.startM - EPS, lte: left.startM + EPS } },
+            orderBy: { endM: 'desc' }
           })
           const leftAfter = await T.findUnique({ where: { id: left.id } })
           if (leftNeighbor && leftNeighbor.id !== leftAfter.id &&
-              Math.abs(leftNeighbor.endKm - leftAfter.startKm) < EPS &&
+              Math.abs(leftNeighbor.endM - leftAfter.startM) < EPS &&
               eqVal(leftNeighbor[meta.valueField], leftAfter[meta.valueField])) {
             await T.delete({ where: { id: leftNeighbor.id } })
-            await T.update({ where: { id: leftAfter.id }, data: { startKm: leftNeighbor.startKm } })
+            await T.update({ where: { id: leftAfter.id }, data: { startM: leftNeighbor.startM } })
           }
 
         } else if (edge === 'start') {
@@ -137,22 +137,22 @@ app.post('/api/roads/:id/bands/:band/move-seam', async (req, res) => {
           const right = await T.findUnique({ where: { id: rightId } })
           if (!right || right.roadId !== roadId) throw new Error('right row missing/mismatch')
 
-          // keep row valid (start < end) with minimal epsilon; otherwise use raw km
-          let newKm = km
-          if (!(newKm < right.endKm - EPS)) newKm = right.endKm - 0.0001
-          await T.update({ where: { id: right.id }, data: { startKm: newKm } })
+          // keep row valid (start < end) with minimal epsilon; otherwise use raw m
+          let newM = m
+          if (!(newM < right.endM - EPS)) newM = right.endM - 0.1
+          await T.update({ where: { id: right.id }, data: { startM: newM } })
 
           // Optional: merge with right neighbor if identical value and contiguous
           const rightNeighbor = await T.findFirst({
-            where: { roadId, startKm: { gte: right.endKm - EPS, lte: right.endKm + EPS } },
-            orderBy: { startKm: 'asc' }
+            where: { roadId, startM: { gte: right.endM - EPS, lte: right.endM + EPS } },
+            orderBy: { startM: 'asc' }
           })
           const rightAfter = await T.findUnique({ where: { id: right.id } })
           if (rightNeighbor && rightNeighbor.id !== rightAfter.id &&
-              Math.abs(rightNeighbor.startKm - rightAfter.endKm) < EPS &&
+              Math.abs(rightNeighbor.startM - rightAfter.endM) < EPS &&
               eqVal(rightNeighbor[meta.valueField], rightAfter[meta.valueField])) {
             await T.delete({ where: { id: rightNeighbor.id } })
-            await T.update({ where: { id: rightAfter.id }, data: { endKm: rightNeighbor.endKm } })
+            await T.update({ where: { id: rightAfter.id }, data: { endM: rightNeighbor.endM } })
           }
         } else {
           throw new Error("edge must be 'start' or 'end' for bridges")
@@ -168,45 +168,45 @@ app.post('/api/roads/:id/bands/:band/move-seam', async (req, res) => {
         if (!left || !right) throw new Error('Seam rows not found')
         if (left.roadId !== roadId || right.roadId !== roadId) throw new Error('Road mismatch')
 
-        if (left.startKm > right.startKm) { const tmp = left; left = right; right = tmp }
+        if (left.startM > right.startM) { const tmp = left; left = right; right = tmp }
 
-        const minKm = left.startKm + 0.0001
-        const maxKm = right.endKm - 0.0001
-        const newKm = clamp(km, minKm, maxKm)
+        const minM = left.startM + 0.1
+        const maxM = right.endM - 0.1
+        const newM = clamp(m, minM, maxM)
 
-        await T.update({ where: { id: left.id },  data: { endKm:   newKm } })
-        await T.update({ where: { id: right.id }, data: { startKm: newKm } })
+        await T.update({ where: { id: left.id },  data: { endM:   newM } })
+        await T.update({ where: { id: right.id }, data: { startM: newM } })
 
         // merge neighbors if equal
         const leftNeighbor = await T.findFirst({
-          where: { roadId, endKm: { gte: left.startKm - EPS, lte: left.startKm + EPS } },
-          orderBy: { endKm: 'desc' }
+          where: { roadId, endM: { gte: left.startM - EPS, lte: left.startM + EPS } },
+          orderBy: { endM: 'desc' }
         })
         const leftAfter = await T.findUnique({ where: { id: left.id } })
         if (leftNeighbor && leftNeighbor.id !== leftAfter.id &&
-            Math.abs(leftNeighbor.endKm - leftAfter.startKm) < EPS &&
+            Math.abs(leftNeighbor.endM - leftAfter.startM) < EPS &&
             eqVal(leftNeighbor[meta.valueField], leftAfter[meta.valueField])) {
           await T.delete({ where: { id: leftNeighbor.id } })
-          await T.update({ where: { id: leftAfter.id }, data: { startKm: leftNeighbor.startKm } })
+          await T.update({ where: { id: leftAfter.id }, data: { startM: leftNeighbor.startM } })
         }
 
         const rightNeighbor = await T.findFirst({
-          where: { roadId, startKm: { gte: right.endKm - EPS, lte: right.endKm + EPS } },
-          orderBy: { startKm: 'asc' }
+          where: { roadId, startM: { gte: right.endM - EPS, lte: right.endM + EPS } },
+          orderBy: { startM: 'asc' }
         })
         const rightAfter = await T.findUnique({ where: { id: right.id } })
         if (rightNeighbor && rightNeighbor.id !== rightAfter.id &&
-            Math.abs(rightNeighbor.startKm - rightAfter.endKm) < EPS &&
+            Math.abs(rightNeighbor.startM - rightAfter.endM) < EPS &&
             eqVal(rightNeighbor[meta.valueField], rightAfter[meta.valueField])) {
           await T.delete({ where: { id: rightNeighbor.id } })
-          await T.update({ where: { id: rightAfter.id }, data: { endKm: rightNeighbor.endKm } })
+          await T.update({ where: { id: rightAfter.id }, data: { endM: rightNeighbor.endM } })
         }
       }
 
       // return fresh rows for this band
       const fresh = await T.findMany({
         where: { roadId },
-        orderBy: [{ startKm:'asc' }, { id:'asc' }]
+        orderBy: [{ startM:'asc' }, { id:'asc' }]
       })
       return fresh
     })


### PR DESCRIPTION
## Summary
- store road geometry in meters instead of kilometers
- introduce Section table for subdividing roads
- update API and seed data to reflect meter-based fields

## Testing
- `npm test` *(fails: Missing script)*
- `npm run prisma:generate`


------
https://chatgpt.com/codex/tasks/task_e_68a720bcbc4883238b79182a2d63be1d