### PR TITLE
Fix SLD viewer unit mismatch for meter-based database

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,26 +1,46 @@
 import axios from 'axios'
 const API = import.meta.env.VITE_API_URL || 'http://localhost:4000'
 
-export async function fetchRoads(q='') {
+export async function fetchRoads(q = '') {
   const { data } = await axios.get(`${API}/api/roads`, { params: { q } })
-  return data
+  return data.map((r) => ({ ...r, lengthKm: (r.lengthM || 0) / 1000 }))
 }
 
 export async function fetchSegments(roadId) {
   const { data } = await axios.get(`${API}/api/roads/${roadId}/segments`)
-  return data
+  const road = data.road ? { ...data.road, lengthKm: (data.road.lengthM || 0) / 1000 } : null
+  const segments = (data.segments || []).map((s) => ({
+    ...s,
+    startKm: s.startM / 1000,
+    endKm: s.endM / 1000,
+  }))
+  return { road, segments }
 }
 
 export async function fetchLayers(roadId) {
   const { data } = await axios.get(`${API}/api/roads/${roadId}/layers`)
-  return data
+  const road = data.road ? { ...data.road, lengthKm: (data.road.lengthM || 0) / 1000 } : null
+  const conv = (arr) => (arr || []).map((r) => ({ ...r, startKm: r.startM / 1000, endKm: r.endM / 1000 }))
+  const kmPosts = (data.kmPosts || []).map((p) => ({ ...p, chainageKm: p.chainageM / 1000 }))
+  return {
+    road,
+    surface: conv(data.surface),
+    aadt: conv(data.aadt),
+    status: conv(data.status),
+    quality: conv(data.quality),
+    lanes: conv(data.lanes),
+    rowWidth: conv(data.rowWidth),
+    municipality: conv(data.municipality),
+    bridges: conv(data.bridges),
+    kmPosts,
+  }
 }
 
 // ✅ Forward arbitrary extras (e.g., { edge: 'start' } for bridges)
 export async function moveBandSeam(roadId, bandKey, leftId, rightId, km, extra = {}) {
   const { data } = await axios.post(
     `${API}/api/roads/${roadId}/bands/${bandKey}/move-seam`,
-    { leftId, rightId, km, ...extra }
+    { leftId, rightId, m: km * 1000, ...extra }
   )
   return data
 }


### PR DESCRIPTION
## Summary
- Convert API responses from meters to kilometers for roads, segments, layers, and km posts
- Send seam positions in meters when editing bands

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a734047d20832388d65ed9c963d4bf