### PR TITLE
Fix KmPost migration for section links

### DIFF
--- a/server/prisma/migrations/20250817180000_connect_bands_to_sections/migration.sql
+++ b/server/prisma/migrations/20250817180000_connect_bands_to_sections/migration.sql
@@ -50,7 +50,8 @@ ALTER INDEX "BridgeBand_roadId_startM_endM_idx" RENAME TO "BridgeBand_section_id
 
 -- KmPost
 ALTER TABLE "KmPost" DROP CONSTRAINT "KmPost_roadId_fkey";
-ALTER TABLE "KmPost" RENAME COLUMN "roadId" TO "section_id";
-ALTER TABLE "KmPost" ADD CONSTRAINT "KmPost_section_id_fkey" FOREIGN KEY ("section_id") REFERENCES "Section"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "KmPost" ADD CONSTRAINT "KmPost_section_id_fkey"
+  FOREIGN KEY ("section_id") REFERENCES "Section"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER INDEX "KmPost_road_chainageM_idx" RENAME TO "KmPost_section_chainageM_idx";
 

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -1,123 +1,102 @@
 /* eslint-disable no-console */
 const { PrismaClient } = require('@prisma/client')
+
 const prisma = new PrismaClient()
 
-async function seedForRoad(road) {
-  const rid = road.id
+async function main() {
+  const road = await prisma.road.create({
+    data: { name: 'NH-12 Demo Corridor', lengthM: 20000 },
+  })
 
-  // Legacy segments (optional, keeps the lane diagram fallback alive)
-  const segments = [
-    { startM:    0,  endM:  4000, lanesLeft: 1, lanesRight: 1, surface: 'Asphalt',  status:'Open',  quality:'Good',      sidewalk:true,  aadt: 18000 },
-    { startM: 4000,  endM:  8000, lanesLeft: 1, lanesRight: 1, surface: 'Concrete', status:'Open',  quality:'Fair',      sidewalk:false, aadt: 26500 },
-    { startM: 8000,  endM: 12500, lanesLeft: 2, lanesRight: 1, surface: 'Concrete', status:'Open',  quality:'Fair',      sidewalk:false, aadt: 28000 },
-    { startM:12500,  endM: 20000, lanesLeft: 2, lanesRight: 2, surface: 'Asphalt',  status:'Closed',quality:'Excellent', sidewalk:true,  aadt: 31000 },
-  ]
-  for (const s of segments) await prisma.segment.create({ data: { roadId: rid, ...s } })
+  const [section1, section2] = await Promise.all([
+    prisma.section.create({ data: { roadId: road.id, startM: 0, endM: 10000 } }),
+    prisma.section.create({ data: { roadId: road.id, startM: 10000, endM: 20000 } }),
+  ])
 
-  const section1 = await prisma.section.create({ data: { roadId: rid, startM: 0, endM: 10000 } })
-  const section2 = await prisma.section.create({ data: { roadId: rid, startM: 10000, endM: 20000 } })
   const sec = (m) => (m < 10000 ? section1.id : section2.id)
 
-  // Independent range bands
   await prisma.surfaceBand.createMany({
     data: [
-      { sectionId: sec(0),      startM:    0, endM:  6000, surface: 'Asphalt'  },
-      { sectionId: sec(6000),   startM: 6000, endM: 12000, surface: 'Concrete' },
-      { sectionId: sec(12000),  startM:12000, endM: 20000, surface: 'Gravel'   },
-    ]
+      { sectionId: sec(0), startM: 0, endM: 6000, surface: 'Asphalt' },
+      { sectionId: sec(6000), startM: 6000, endM: 12000, surface: 'Concrete' },
+      { sectionId: sec(12000), startM: 12000, endM: 20000, surface: 'Gravel' },
+    ],
   })
 
   await prisma.aadtBand.createMany({
     data: [
-      { sectionId: sec(0),      startM:    0, endM:  5000, aadt: 16000 },
-      { sectionId: sec(5000),   startM: 5000, endM: 12000, aadt: 27000 },
-      { sectionId: sec(12000),  startM:12000, endM: 20000, aadt: 32000 },
-    ]
+      { sectionId: sec(0), startM: 0, endM: 5000, aadt: 16000 },
+      { sectionId: sec(5000), startM: 5000, endM: 12000, aadt: 27000 },
+      { sectionId: sec(12000), startM: 12000, endM: 20000, aadt: 32000 },
+    ],
   })
 
   await prisma.statusBand.createMany({
     data: [
-      { sectionId: sec(0),      startM:    0, endM: 14000, status: 'Open'   },
-      { sectionId: sec(14000),  startM:14000, endM: 20000, status: 'Closed' },
-    ]
+      { sectionId: sec(0), startM: 0, endM: 14000, status: 'Open' },
+      { sectionId: sec(14000), startM: 14000, endM: 20000, status: 'Closed' },
+    ],
   })
 
   await prisma.qualityBand.createMany({
     data: [
-      { sectionId: sec(0),      startM:    0, endM:  4000, quality: 'Good'      },
-      { sectionId: sec(4000),   startM: 4000, endM: 10000, quality: 'Fair'      },
-      { sectionId: sec(10000),  startM:10000, endM: 20000, quality: 'Excellent' },
-    ]
+      { sectionId: sec(0), startM: 0, endM: 4000, quality: 'Good' },
+      { sectionId: sec(4000), startM: 4000, endM: 10000, quality: 'Fair' },
+      { sectionId: sec(10000), startM: 10000, endM: 20000, quality: 'Excellent' },
+    ],
   })
 
   await prisma.lanesBand.createMany({
     data: [
-      { sectionId: sec(0),      startM:    0, endM:  6000, lanes: 2 },
-      { sectionId: sec(6000),   startM: 6000, endM: 12000, lanes: 3 },
-      { sectionId: sec(12000),  startM:12000, endM: 20000, lanes: 4 },
-    ]
+      { sectionId: sec(0), startM: 0, endM: 6000, lanes: 2 },
+      { sectionId: sec(6000), startM: 6000, endM: 12000, lanes: 3 },
+      { sectionId: sec(12000), startM: 12000, endM: 20000, lanes: 4 },
+    ],
   })
 
   await prisma.rowWidthBand.createMany({
     data: [
-      { sectionId: sec(0),    startM:    0, endM:  8000, rowWidthM: 20 },
+      { sectionId: sec(0), startM: 0, endM: 8000, rowWidthM: 20 },
       { sectionId: sec(8000), startM: 8000, endM: 20000, rowWidthM: 30 },
-    ]
+    ],
   })
 
   await prisma.municipalityBand.createMany({
     data: [
-      { sectionId: sec(0),     startM:    0, endM:  7500, name: 'San Isidro' },
-      { sectionId: sec(7500),  startM: 7500, endM: 14000, name: 'Sta. Maria' },
-      { sectionId: sec(14000), startM:14000, endM: 20000, name: 'San Rafael' },
-    ]
+      { sectionId: sec(0), startM: 0, endM: 7500, name: 'San Isidro' },
+      { sectionId: sec(7500), startM: 7500, endM: 14000, name: 'Sta. Maria' },
+      { sectionId: sec(14000), startM: 14000, endM: 20000, name: 'San Rafael' },
+    ],
   })
 
   await prisma.bridgeBand.createMany({
     data: [
-      { sectionId: sec(3200),  startM:  3200, endM:  3500, name: 'Mabini Bridge'  },
-      { sectionId: sec(11000), startM: 11000, endM: 11200, name: 'Carmelita Br.'  },
-    ]
+      { sectionId: sec(3200), startM: 3200, endM: 3500, name: 'Mabini Bridge' },
+      { sectionId: sec(11000), startM: 11000, endM: 11200, name: 'Carmelita Br.' },
+    ],
   })
 
   await prisma.kmPost.createMany({
     data: [
-      { sectionId: sec(0),     chainageM:    0, lrp: 'KM 0'  },
-      { sectionId: sec(1000),  chainageM: 1000, lrp: 'KM 1'  },
-      { sectionId: sec(2000),  chainageM: 2000, lrp: 'KM 2'  },
-      { sectionId: sec(5000),  chainageM: 5000, lrp: 'KM 5'  },
-      { sectionId: sec(10000), chainageM:10000, lrp: 'KM 10' },
-      { sectionId: sec(15000), chainageM:15000, lrp: 'KM 15' },
-      { sectionId: sec(20000), chainageM:20000, lrp: 'KM 20' },
-    ]
+      { sectionId: sec(0), chainageM: 0, lrp: 'KM 0' },
+      { sectionId: sec(1000), chainageM: 1000, lrp: 'KM 1' },
+      { sectionId: sec(2000), chainageM: 2000, lrp: 'KM 2' },
+      { sectionId: sec(5000), chainageM: 5000, lrp: 'KM 5' },
+      { sectionId: sec(10000), chainageM: 10000, lrp: 'KM 10' },
+      { sectionId: sec(15000), chainageM: 15000, lrp: 'KM 15' },
+      { sectionId: sec(20000), chainageM: 20000, lrp: 'KM 20' },
+    ],
   })
-}
 
-async function main() {
-  let road = await prisma.road.findFirst()
-  if (!road) {
-    road = await prisma.road.create({ data: { name: 'NH-12 Demo Corridor', lengthM: 20000 } })
-    await seedForRoad(road)
-    console.log('🌱 Seeded NH-12 with independent bands + km posts')
-  } else {
-    // ensure at least some bands exist
-    const counts = await Promise.all([
-      prisma.surfaceBand.count(),
-      prisma.lanesBand.count(),
-    ])
-    if (counts[0] === 0 || counts[1] === 0) {
-      await seedForRoad(road)
-      console.log('🌱 Backfilled bands for existing road')
-    } else {
-      console.log('✅ Seed skipped: data present')
-    }
-  }
+  console.log('🌱 Seeded NH-12 with section-based bands and km posts')
 }
 
 main()
-  .then(async () => await prisma.$disconnect())
   .catch(async (e) => {
     console.error(e)
     await prisma.$disconnect()
     process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
   })


### PR DESCRIPTION
## Summary
- fix KmPost migration to use existing `section_id` and add foreign key
- add new Prisma seed script aligned with section-based schema

## Testing
- `npx prisma migrate dev` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*
- `npx prisma generate` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a747dee3248323a791270d13754e2e