### PR TITLE
Use camelCase sectionId field in Prisma queries

### DIFF
--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -17,74 +17,74 @@ async function main() {
 
   await prisma.surfaceBand.createMany({
     data: [
-      { section_id: sec(0), startM: 0, endM: 6000, surface: 'Asphalt' },
-      { section_id: sec(6000), startM: 6000, endM: 12000, surface: 'Concrete' },
-      { section_id: sec(12000), startM: 12000, endM: 20000, surface: 'Gravel' },
+      { sectionId: sec(0), startM: 0, endM: 6000, surface: 'Asphalt' },
+      { sectionId: sec(6000), startM: 6000, endM: 12000, surface: 'Concrete' },
+      { sectionId: sec(12000), startM: 12000, endM: 20000, surface: 'Gravel' },
     ],
   })
 
   await prisma.aadtBand.createMany({
     data: [
-      { section_id: sec(0), startM: 0, endM: 5000, aadt: 16000 },
-      { section_id: sec(5000), startM: 5000, endM: 12000, aadt: 27000 },
-      { section_id: sec(12000), startM: 12000, endM: 20000, aadt: 32000 },
+      { sectionId: sec(0), startM: 0, endM: 5000, aadt: 16000 },
+      { sectionId: sec(5000), startM: 5000, endM: 12000, aadt: 27000 },
+      { sectionId: sec(12000), startM: 12000, endM: 20000, aadt: 32000 },
     ],
   })
 
   await prisma.statusBand.createMany({
     data: [
-      { section_id: sec(0), startM: 0, endM: 14000, status: 'Open' },
-      { section_id: sec(14000), startM: 14000, endM: 20000, status: 'Closed' },
+      { sectionId: sec(0), startM: 0, endM: 14000, status: 'Open' },
+      { sectionId: sec(14000), startM: 14000, endM: 20000, status: 'Closed' },
     ],
   })
 
   await prisma.qualityBand.createMany({
     data: [
-      { section_id: sec(0), startM: 0, endM: 4000, quality: 'Good' },
-      { section_id: sec(4000), startM: 4000, endM: 10000, quality: 'Fair' },
-      { section_id: sec(10000), startM: 10000, endM: 20000, quality: 'Excellent' },
+      { sectionId: sec(0), startM: 0, endM: 4000, quality: 'Good' },
+      { sectionId: sec(4000), startM: 4000, endM: 10000, quality: 'Fair' },
+      { sectionId: sec(10000), startM: 10000, endM: 20000, quality: 'Excellent' },
     ],
   })
 
   await prisma.lanesBand.createMany({
     data: [
-      { section_id: sec(0), startM: 0, endM: 6000, lanes: 2 },
-      { section_id: sec(6000), startM: 6000, endM: 12000, lanes: 3 },
-      { section_id: sec(12000), startM: 12000, endM: 20000, lanes: 4 },
+      { sectionId: sec(0), startM: 0, endM: 6000, lanes: 2 },
+      { sectionId: sec(6000), startM: 6000, endM: 12000, lanes: 3 },
+      { sectionId: sec(12000), startM: 12000, endM: 20000, lanes: 4 },
     ],
   })
 
   await prisma.rowWidthBand.createMany({
     data: [
-      { section_id: sec(0), startM: 0, endM: 8000, rowWidthM: 20 },
-      { section_id: sec(8000), startM: 8000, endM: 20000, rowWidthM: 30 },
+      { sectionId: sec(0), startM: 0, endM: 8000, rowWidthM: 20 },
+      { sectionId: sec(8000), startM: 8000, endM: 20000, rowWidthM: 30 },
     ],
   })
 
   await prisma.municipalityBand.createMany({
     data: [
-      { section_id: sec(0), startM: 0, endM: 7500, name: 'San Isidro' },
-      { section_id: sec(7500), startM: 7500, endM: 14000, name: 'Sta. Maria' },
-      { section_id: sec(14000), startM: 14000, endM: 20000, name: 'San Rafael' },
+      { sectionId: sec(0), startM: 0, endM: 7500, name: 'San Isidro' },
+      { sectionId: sec(7500), startM: 7500, endM: 14000, name: 'Sta. Maria' },
+      { sectionId: sec(14000), startM: 14000, endM: 20000, name: 'San Rafael' },
     ],
   })
 
   await prisma.bridgeBand.createMany({
     data: [
-      { section_id: sec(3200), startM: 3200, endM: 3500, name: 'Mabini Bridge' },
-      { section_id: sec(11000), startM: 11000, endM: 11200, name: 'Carmelita Br.' },
+      { sectionId: sec(3200), startM: 3200, endM: 3500, name: 'Mabini Bridge' },
+      { sectionId: sec(11000), startM: 11000, endM: 11200, name: 'Carmelita Br.' },
     ],
   })
 
   await prisma.kmPost.createMany({
     data: [
-      { section_id: sec(0), chainageM: 0, lrp: 'KM 0' },
-      { section_id: sec(1000), chainageM: 1000, lrp: 'KM 1' },
-      { section_id: sec(2000), chainageM: 2000, lrp: 'KM 2' },
-      { section_id: sec(5000), chainageM: 5000, lrp: 'KM 5' },
-      { section_id: sec(10000), chainageM: 10000, lrp: 'KM 10' },
-      { section_id: sec(15000), chainageM: 15000, lrp: 'KM 15' },
-      { section_id: sec(20000), chainageM: 20000, lrp: 'KM 20' },
+      { sectionId: sec(0), chainageM: 0, lrp: 'KM 0' },
+      { sectionId: sec(1000), chainageM: 1000, lrp: 'KM 1' },
+      { sectionId: sec(2000), chainageM: 2000, lrp: 'KM 2' },
+      { sectionId: sec(5000), chainageM: 5000, lrp: 'KM 5' },
+      { sectionId: sec(10000), chainageM: 10000, lrp: 'KM 10' },
+      { sectionId: sec(15000), chainageM: 15000, lrp: 'KM 15' },
+      { sectionId: sec(20000), chainageM: 20000, lrp: 'KM 20' },
     ],
   })
 

--- a/server/server.js
+++ b/server/server.js
@@ -67,15 +67,15 @@ app.get('/api/roads/:id/layers', async (req, res) => {
   const [
     surface, aadt, status, quality, lanes, rowWidth, municipality, bridges, kmPosts
   ] = await Promise.all([
-    prisma.surfaceBand.findMany({ where: { section_id: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
-    prisma.aadtBand.findMany({ where: { section_id: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
-    prisma.statusBand.findMany({ where: { section_id: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
-    prisma.qualityBand.findMany({ where: { section_id: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
-    prisma.lanesBand.findMany({ where: { section_id: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
-    prisma.rowWidthBand.findMany({ where: { section_id: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
-    prisma.municipalityBand.findMany({ where: { section_id: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
-    prisma.bridgeBand.findMany({ where: { section_id: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
-    prisma.kmPost.findMany({ where: { section_id: { in: sectionIds } }, orderBy: [{ chainageM:'asc' }, { id:'asc' }] }),
+    prisma.surfaceBand.findMany({ where: { sectionId: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.aadtBand.findMany({ where: { sectionId: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.statusBand.findMany({ where: { sectionId: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.qualityBand.findMany({ where: { sectionId: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.lanesBand.findMany({ where: { sectionId: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.rowWidthBand.findMany({ where: { sectionId: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.municipalityBand.findMany({ where: { sectionId: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.bridgeBand.findMany({ where: { sectionId: { in: sectionIds } }, orderBy: [{ startM:'asc' }, { id:'asc' }] }),
+    prisma.kmPost.findMany({ where: { sectionId: { in: sectionIds } }, orderBy: [{ chainageM:'asc' }, { id:'asc' }] }),
   ])
 
   res.json({ road, sections, surface, aadt, status, quality, lanes, rowWidth, municipality, bridges, kmPosts })
@@ -117,7 +117,7 @@ app.post('/api/roads/:id/bands/:band/move-seam', async (req, res) => {
         if (edge === 'end') {
           if (!Number.isFinite(leftId)) throw new Error('leftId required for edge=end')
           const left = await T.findUnique({ where: { id: leftId } })
-          if (!left || !sectionSet.has(left.section_id)) throw new Error('left row missing/mismatch')
+          if (!left || !sectionSet.has(left.sectionId)) throw new Error('left row missing/mismatch')
 
           // keep row valid (end > start) with minimal epsilon; otherwise use raw m
           let newM = m
@@ -126,7 +126,7 @@ app.post('/api/roads/:id/bands/:band/move-seam', async (req, res) => {
 
           // Optional: merge with left neighbor if identical value and contiguous
           const leftNeighbor = await T.findFirst({
-            where: { section_id: { in: sectionIds }, endM: { gte: left.startM - EPS, lte: left.startM + EPS } },
+            where: { sectionId: { in: sectionIds }, endM: { gte: left.startM - EPS, lte: left.startM + EPS } },
             orderBy: { endM: 'desc' }
           })
           const leftAfter = await T.findUnique({ where: { id: left.id } })
@@ -140,7 +140,7 @@ app.post('/api/roads/:id/bands/:band/move-seam', async (req, res) => {
         } else if (edge === 'start') {
           if (!Number.isFinite(rightId)) throw new Error('rightId required for edge=start')
           const right = await T.findUnique({ where: { id: rightId } })
-          if (!right || !sectionSet.has(right.section_id)) throw new Error('right row missing/mismatch')
+          if (!right || !sectionSet.has(right.sectionId)) throw new Error('right row missing/mismatch')
 
           // keep row valid (start < end) with minimal epsilon; otherwise use raw m
           let newM = m
@@ -149,7 +149,7 @@ app.post('/api/roads/:id/bands/:band/move-seam', async (req, res) => {
 
           // Optional: merge with right neighbor if identical value and contiguous
           const rightNeighbor = await T.findFirst({
-            where: { section_id: { in: sectionIds }, startM: { gte: right.endM - EPS, lte: right.endM + EPS } },
+            where: { sectionId: { in: sectionIds }, startM: { gte: right.endM - EPS, lte: right.endM + EPS } },
             orderBy: { startM: 'asc' }
           })
           const rightAfter = await T.findUnique({ where: { id: right.id } })
@@ -171,7 +171,7 @@ app.post('/api/roads/:id/bands/:band/move-seam', async (req, res) => {
         let left = await T.findUnique({ where: { id: leftId } })
         let right = await T.findUnique({ where: { id: rightId } })
         if (!left || !right) throw new Error('Seam rows not found')
-        if (!sectionSet.has(left.section_id) || !sectionSet.has(right.section_id)) throw new Error('Road mismatch')
+        if (!sectionSet.has(left.sectionId) || !sectionSet.has(right.sectionId)) throw new Error('Road mismatch')
 
         if (left.startM > right.startM) { const tmp = left; left = right; right = tmp }
 
@@ -184,7 +184,7 @@ app.post('/api/roads/:id/bands/:band/move-seam', async (req, res) => {
 
         // merge neighbors if equal
         const leftNeighbor = await T.findFirst({
-          where: { section_id: { in: sectionIds }, endM: { gte: left.startM - EPS, lte: left.startM + EPS } },
+          where: { sectionId: { in: sectionIds }, endM: { gte: left.startM - EPS, lte: left.startM + EPS } },
           orderBy: { endM: 'desc' }
         })
         const leftAfter = await T.findUnique({ where: { id: left.id } })
@@ -196,7 +196,7 @@ app.post('/api/roads/:id/bands/:band/move-seam', async (req, res) => {
         }
 
         const rightNeighbor = await T.findFirst({
-          where: { section_id: { in: sectionIds }, startM: { gte: right.endM - EPS, lte: right.endM + EPS } },
+          where: { sectionId: { in: sectionIds }, startM: { gte: right.endM - EPS, lte: right.endM + EPS } },
           orderBy: { startM: 'asc' }
         })
         const rightAfter = await T.findUnique({ where: { id: right.id } })
@@ -210,7 +210,7 @@ app.post('/api/roads/:id/bands/:band/move-seam', async (req, res) => {
 
       // return fresh rows for this band
       const fresh = await T.findMany({
-        where: { section_id: { in: sectionIds } },
+        where: { sectionId: { in: sectionIds } },
         orderBy: [{ startM:'asc' }, { id:'asc' }]
       })
       return fresh


### PR DESCRIPTION
## Summary
- align server queries and seed data with Prisma's `sectionId` field

## Testing
- `npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a75cf3f4508323a02365cc2ac7bc05