### PR TITLE
Ensure SLDCanvas shows default bands

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,17 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { fetchRoads, fetchSegments, fetchLayers, moveBandSeam } from './api'
 import ControlBar from './components/ControlBar'
 import SLDCanvasV2 from './components/SLDCanvasV2'
-
-const DEFAULT_BANDS = [
-  { key: 'surface',      title: 'Surface',            height: 28 },
-  { key: 'aadt',         title: 'AADT',               height: 28 },
-  { key: 'status',       title: 'Status',             height: 28 },
-  { key: 'quality',      title: 'Condition',          height: 28 },
-  { key: 'rowWidth',     title: 'ROW Width (m)',      height: 28 },
-  { key: 'lanes',        title: 'Number of Lanes',    height: 28 },
-  { key: 'municipality', title: 'Municipality',       height: 28 },
-  { key: 'bridges',      title: 'Bridges',            height: 24 },
-]
+import { DEFAULT_BANDS } from './bands'
 
 export default function App() {
   const [roads, setRoads] = useState([])

--- a/client/src/bands.js
+++ b/client/src/bands.js
@@ -1,0 +1,10 @@
+export const DEFAULT_BANDS = [
+  { key: 'surface',      title: 'Surface',            height: 28 },
+  { key: 'aadt',         title: 'AADT',               height: 28 },
+  { key: 'status',       title: 'Status',             height: 28 },
+  { key: 'quality',      title: 'Condition',          height: 28 },
+  { key: 'rowWidth',     title: 'ROW Width (m)',      height: 28 },
+  { key: 'lanes',        title: 'Number of Lanes',    height: 28 },
+  { key: 'municipality', title: 'Municipality',       height: 28 },
+  { key: 'bridges',      title: 'Bridges',            height: 24 },
+]

--- a/client/src/components/SLDCanvasV2.jsx
+++ b/client/src/components/SLDCanvasV2.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { DEFAULT_BANDS } from '../bands'
 
 const SURFACE_COLORS = { Asphalt:'#282828', Concrete:'#a1a1a1', Gravel:'#8d6e63' }
 const QUALITY_COLORS = { Poor:'#e53935', Fair:'#fb8c00', Good:'#43a047', Excellent:'#1e88e5' }
@@ -31,7 +32,7 @@ export default function SLDCanvasV2({
   layers,
   domain,
   onDomainChange,
-  bands,
+  bands = DEFAULT_BANDS,
   onMoveSeam,        // (bandKey, leftId, rightId, km, extra={})
 }) {
   const canvasRef = useRef(null)


### PR DESCRIPTION
## Summary
- add shared DEFAULT_BANDS definition and reuse it
- make SLDCanvasV2 fall back to DEFAULT_BANDS when no bands prop is provided

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a766742538832390ce0eec4680fa98