### PR TITLE
Remove legacy Segment table usage

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { fetchRoads, fetchSegments, fetchLayers, moveBandSeam } from './api'
+import { fetchRoads, fetchLayers, moveBandSeam } from './api'
 import ControlBar from './components/ControlBar'
 import SLDCanvasV2 from './components/SLDCanvasV2'
 import { DEFAULT_BANDS } from './bands'
@@ -10,7 +10,6 @@ export default function App() {
   const [road, setRoad] = useState(null)
   const [sectionList, setSectionList] = useState([])
   const [sectionId, setSectionId] = useState(null)
-  const [segments, setSegments] = useState([])
   const [allLayers, setAllLayers] = useState(null)
   const [layers, setLayers] = useState(null)
 
@@ -36,30 +35,23 @@ export default function App() {
   useEffect(() => {
     if (!road) return
     ;(async () => {
-      const seg = await fetchSegments(road.id)
-      const list = seg.segments || []
+      const ly = await fetchLayers(road.id)
+      setAllLayers(ly)
+      const list = ly.sections || []
       setSectionList(list)
       const first = list[0]
       setSectionId(first?.id || null)
-
-      const ly = await fetchLayers(road.id)
-      setAllLayers(ly)
     })()
   }, [road])
 
   useEffect(() => {
-    if (!sectionId) { setSegments([]); setLayers(null); return }
+    if (!sectionId) { setLayers(null); return }
     const section = sectionList.find(s => s.id === sectionId)
-    if (!section) { setSegments([]); setLayers(null); return }
+    if (!section) { setLayers(null); return }
     const start = section.startKm
     const end   = section.endKm
     const length = end - start
     setFromKm(0); setToKm(length)
-
-    const segs = sectionList
-      .filter(s => s.endKm > start && s.startKm < end)
-      .map(s => ({ ...s, startKm: s.startKm - start, endKm: s.endKm - start }))
-    setSegments(segs)
 
     const slice = (arr = []) => arr
       .filter(r => r.endKm > start && r.startKm < end)
@@ -139,7 +131,6 @@ export default function App() {
 
         <SLDCanvasV2
           road={currentRoad}
-          segments={segments}
           layers={layers}
           domain={domain}
           onDomainChange={(a,b)=>{ setFromKm(a); setToKm(b) }}

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -6,24 +6,15 @@ export async function fetchRoads(q = '') {
   return data.map((r) => ({ ...r, lengthKm: (r.lengthM || 0) / 1000 }))
 }
 
-export async function fetchSegments(roadId) {
-  const { data } = await axios.get(`${API}/api/roads/${roadId}/segments`)
-  const road = data.road ? { ...data.road, lengthKm: (data.road.lengthM || 0) / 1000 } : null
-  const segments = (data.segments || []).map((s) => ({
-    ...s,
-    startKm: s.startM / 1000,
-    endKm: s.endM / 1000,
-  }))
-  return { road, segments }
-}
-
 export async function fetchLayers(roadId) {
   const { data } = await axios.get(`${API}/api/roads/${roadId}/layers`)
   const road = data.road ? { ...data.road, lengthKm: (data.road.lengthM || 0) / 1000 } : null
   const conv = (arr) => (arr || []).map((r) => ({ ...r, startKm: r.startM / 1000, endKm: r.endM / 1000 }))
   const kmPosts = (data.kmPosts || []).map((p) => ({ ...p, chainageKm: p.chainageM / 1000 }))
+  const sections = conv(data.sections)
   return {
     road,
+    sections,
     surface: conv(data.surface),
     aadt: conv(data.aadt),
     status: conv(data.status),

--- a/client/src/components/SLDCanvasV2.jsx
+++ b/client/src/components/SLDCanvasV2.jsx
@@ -28,7 +28,6 @@ function formatAADT(n){ return (n==null)? '' : String(n).replace(/\B(?=(\d{3})+(
 
 export default function SLDCanvasV2({
   road,
-  segments = [],
   layers,
   domain,
   onDomainChange,
@@ -115,20 +114,12 @@ export default function SLDCanvasV2({
   const lanesAt = (km) => {
     const arr = layers?.lanes || []
     for (const r of arr) if (km >= r.startKm - EPS && km <= r.endKm + EPS) return Math.max(1, r.lanes)
-    let best = 2
-    for (const s of segments) {
-      if (km >= s.startKm - EPS && km <= s.endKm + EPS) {
-        const total = Math.max(1, (s.lanesLeft||0) + (s.lanesRight||0))
-        best = Math.max(best, total)
-      }
-    }
-    return best
+    return 2
   }
 
   const surfaceAt = (km) => {
     const arr = layers?.surface || []
     for (const r of arr) if (km >= r.startKm - EPS && km <= r.endKm + EPS) return r.surface
-    for (const s of segments) if (km >= s.startKm - EPS && km <= s.endKm + EPS) return s.surface || 'Asphalt'
     return 'Asphalt'
   }
 
@@ -290,7 +281,7 @@ export default function SLDCanvasV2({
         useEffect(() => {
           cancelAnimationFrame(rafRef.current)
           rafRef.current = requestAnimationFrame(() => draw())
-        }, [fromKm, toKm, panX, zoom, layout, layers, segments]) // eslint-disable-line react-hooks/exhaustive-deps
+        }, [fromKm, toKm, panX, zoom, layout, layers]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // ---------- interactions ----------
   const bandArrayByKey = (key) => {

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -15,28 +15,10 @@ model Road {
   lengthM  Float
 
   // back-relations (required so Prisma is happy)
-  segments          Segment[]
   sections          Section[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-}
-
-model Segment {
-    id         Int      @id @default(autoincrement())
-    roadId     Int
-    startM     Float
-    endM       Float
-    surface    String?
-    lanesLeft  Int?
-    lanesRight Int?
-    status     String?
-    quality    String?
-    road       Road     @relation(fields: [roadId], references: [id])
-    createdAt  DateTime @default(now())
-    updatedAt  DateTime @updatedAt
-
-  @@index([roadId, startM, endM])
 }
 
 model Section {

--- a/server/server.js
+++ b/server/server.js
@@ -44,18 +44,6 @@ app.get('/api/roads', async (req, res) => {
   res.json(roads)
 })
 
-// legacy segments (optional)
-app.get('/api/roads/:id/segments', async (req, res) => {
-  const roadId = Number(req.params.id)
-  const road = await prisma.road.findUnique({ where: { id: roadId } })
-  if (!road) return res.status(404).json({ error: 'Road not found' })
-  const segments = await prisma.segment.findMany({
-    where: { roadId },
-    orderBy: [{ startM:'asc' }, { id:'asc' }],
-  })
-  res.json({ road, segments })
-})
-
 // all layers (per-band tables)
 app.get('/api/roads/:id/layers', async (req, res) => {
   const roadId = Number(req.params.id)


### PR DESCRIPTION
## Summary
- Drop Segment model from Prisma schema and server endpoints
- Fetch sections and band data from per-band tables instead of legacy segments
- Simplify client canvas and data flow to rely solely on section-based bands

## Testing
- `npm test` *(fails: Missing script)*
- `cd client && npm test` *(fails: Missing script)*
- `cd client && npm run lint`
- `cd server && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e220cc5c83239c45697774c3c686