### PR TITLE
Improve axis tick visibility and sub-interval behavior

### DIFF
--- a/client/src/components/SLDCanvasV2.jsx
+++ b/client/src/components/SLDCanvasV2.jsx
@@ -12,7 +12,7 @@ const MARK_THICK = 3
 const KM_POST_H = 20
 const KM_POST_LABEL_H = 14
 const KM_POST_GAP = 4
-const KM_POST_Y_OFFSET = -6
+const KM_POST_Y_OFFSET = -18
 
 const GAP = 8
 const TOP_PAD = 24

--- a/client/src/components/SLDCanvasV2.jsx
+++ b/client/src/components/SLDCanvasV2.jsx
@@ -202,7 +202,7 @@ export default function SLDCanvasV2({
       if (spanM < 100) stepM = 10
       else if (spanM < 500) stepM = 25
       else if (spanM < 1000) stepM = 50
-      else if (spanM < 2000) stepM = 100
+      else if (spanM < 3000) stepM = 100
       const stepKm = stepM / 1000
       const showSub = stepKm < 1
       const kmPostsArr = (layers?.kmPosts || []).slice().sort((a, b) => a.chainageKm - b.chainageKm)
@@ -227,8 +227,8 @@ export default function SLDCanvasV2({
             const startKm = Math.max(fromKm, p.chainageKm)
             const endKm = Math.min(toKm, nextP.chainageKm)
             let m = Math.ceil((startKm - p.chainageKm) / stepKm) * stepKm + p.chainageKm
-            for (; m < endKm - 1e-9; m += stepKm) {
-              if (Math.abs(m - p.chainageKm) < 1e-9 || m > nextP.chainageKm - 1e-9) break
+            if (m <= p.chainageKm + 1e-9) m += stepKm
+            for (; m < endKm - 1e-9 && m < nextP.chainageKm - 1e-9; m += stepKm) {
               const x = kmToX(m)
               ctx.beginPath()
               ctx.moveTo(x, layout.axisY)


### PR DESCRIPTION
## Summary
- Prevent disappearance of interval marks when panning by skipping boundary duplicate and clamping loop range
- Show 100 m markings when zoomed in closer than 3 km

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a80720bfdc8323a9f1c241bfc99f5f