### PR TITLE
Add toggleable ruler guide with LRP tooltip

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -16,6 +16,8 @@ export default function App() {
   const [fromKm, setFromKm] = useState(0)
   const [toKm, setToKm] = useState(10)
 
+  const [showGuide, setShowGuide] = useState(false)
+
   const [bands] = useState(() => DEFAULT_BANDS)
   const domain = useMemo(() => ({ fromKm, toKm }), [fromKm, toKm])
   const currentSection = useMemo(() => sectionList.find(s => s.id === sectionId) || null, [sectionList, sectionId])
@@ -127,6 +129,8 @@ export default function App() {
           road={currentRoad}
           domain={domain}
           onDomainChange={(a,b)=>{ setFromKm(a); setToKm(b) }}
+          showGuide={showGuide}
+          onToggleGuide={()=>setShowGuide(g=>!g)}
         />
 
         <SLDCanvasV2
@@ -136,6 +140,7 @@ export default function App() {
           onDomainChange={(a,b)=>{ setFromKm(a); setToKm(b) }}
           bands={bands}
           onMoveSeam={handleMoveSeam}
+          showGuide={showGuide}
         />
       </div>
     </div>

--- a/client/src/components/ControlBar.jsx
+++ b/client/src/components/ControlBar.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 
-export default function ControlBar({ road, domain, onDomainChange }) {
+export default function ControlBar({ road, domain, onDomainChange, showGuide, onToggleGuide }) {
   const lengthKm = Number(road?.lengthKm || 0)
   const from = domain?.fromKm ?? 0
   const to   = domain?.toKm ?? Math.max(10, lengthKm)
@@ -28,6 +28,9 @@ export default function ControlBar({ road, domain, onDomainChange }) {
     <div style={{ display:'flex', alignItems:'center', gap:8, margin:'8px 0' }}>
       <div><b>LRM</b>: {fromM}–{toM} m</div>
       <div style={{ marginLeft:'auto', display:'flex', gap:6 }}>
+        <button onClick={onToggleGuide} title="Toggle guide" style={{ fontSize:16, background: showGuide ? '#ffd54f' : undefined }}>
+          📏
+        </button>
         <button onClick={()=>jump(-1)}>◀ Pan 1km</button>
         <button onClick={()=>jump(+1)}>Pan 1km ▶</button>
         <button onClick={()=>zoom(0.8)}>Zoom In</button>


### PR DESCRIPTION
## Summary
- add icon-only button to toggle vertical guide line
- offset band tooltips and show chainage tooltip on the ruler

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a80ea8f54c8323944caa401107d292