### PR TITLE
Use string identifiers for roads and sections

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -112,13 +112,13 @@ export default function App() {
             <button onClick={onSearch}>Search</button>
             <select
               value={road?.id || ''}
-              onChange={(e)=>{ const next = roads.find(r=>r.id===Number(e.target.value)); setRoad(next||null) }}
+              onChange={(e)=>{ const next = roads.find(r=>r.id===e.target.value); setRoad(next||null) }}
             >
               {roads.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
             </select>
             <select
               value={sectionId || ''}
-              onChange={(e)=>setSectionId(Number(e.target.value))}
+              onChange={(e)=>setSectionId(e.target.value)}
             >
               {sectionList.map(s => <option key={s.id} value={s.id}>{s.id}</option>)}
             </select>

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
 // ---- Core entities ----------------------------------------------------------
 
 model Road {
-  id       Int    @id @default(autoincrement())
+  id       String @id
   name     String
   lengthM  Float
 
@@ -24,7 +24,7 @@ model Road {
 
 model Segment {
     id         Int      @id @default(autoincrement())
-    roadId     Int
+    roadId     String
     startM     Float
     endM       Float
     surface    String?
@@ -40,8 +40,8 @@ model Segment {
 }
 
 model Section {
-  id       Int      @id @default(autoincrement())
-  roadId   Int
+  id       String   @id
+  roadId   String
   startM   Float
   endM     Float
   road     Road     @relation(fields: [roadId], references: [id])
@@ -63,45 +63,45 @@ model Section {
 // ---- Per-band range tables --------------------------------------------------
 
 model SurfaceBand {
-  id      Int    @id @default(autoincrement())
-  sectionId Int     @map("section_id")
-  startM  Float
-  endM    Float
-  surface String
-  section Section @relation(fields: [sectionId], references: [id])
+  id        Int    @id @default(autoincrement())
+  sectionId String @map("section_id")
+  startM    Float
+  endM      Float
+  surface   String
+  section   Section @relation(fields: [sectionId], references: [id])
 
   @@index([sectionId, startM, endM])
 }
 
 model AadtBand {
-  id      Int   @id @default(autoincrement())
-  sectionId Int     @map("section_id")
-  startM  Float
-  endM    Float
-  aadt    Int
-  section Section @relation(fields: [sectionId], references: [id])
+  id        Int   @id @default(autoincrement())
+  sectionId String @map("section_id")
+  startM    Float
+  endM      Float
+  aadt      Int
+  section   Section @relation(fields: [sectionId], references: [id])
 
   @@index([sectionId, startM, endM])
 }
 
 model StatusBand {
-  id      Int    @id @default(autoincrement())
-  sectionId Int     @map("section_id")
-  startM  Float
-  endM    Float
-  status  String
-  section Section @relation(fields: [sectionId], references: [id])
+  id        Int    @id @default(autoincrement())
+  sectionId String @map("section_id")
+  startM    Float
+  endM      Float
+  status    String
+  section   Section @relation(fields: [sectionId], references: [id])
 
   @@index([sectionId, startM, endM])
 }
 
 model QualityBand {
-  id      Int    @id @default(autoincrement())
-  sectionId Int     @map("section_id")
-  startM  Float
-  endM    Float
-  quality String
-  section Section @relation(fields: [sectionId], references: [id])
+  id        Int    @id @default(autoincrement())
+  sectionId String @map("section_id")
+  startM    Float
+  endM      Float
+  quality   String
+  section   Section @relation(fields: [sectionId], references: [id])
 
   @@index([sectionId, startM, endM])
 }
@@ -113,20 +113,20 @@ enum SideBias {
 }
 
 model LanesBand {
-  id       Int      @id @default(autoincrement())
-  sectionId Int     @map("section_id")
-  startM   Float
-  endM     Float
-  lanes    Int
-  sideBias SideBias @default(TOP)
-  section  Section  @relation(fields: [sectionId], references: [id])
+  id        Int      @id @default(autoincrement())
+  sectionId String   @map("section_id")
+  startM    Float
+  endM      Float
+  lanes     Int
+  sideBias  SideBias @default(TOP)
+  section   Section  @relation(fields: [sectionId], references: [id])
 
   @@index([sectionId, startM, endM])
 }
 
 model RowWidthBand {
-  id        Int   @id @default(autoincrement())
-  sectionId Int     @map("section_id")
+  id        Int    @id @default(autoincrement())
+  sectionId String @map("section_id")
   startM    Float
   endM      Float
   rowWidthM Int
@@ -136,23 +136,23 @@ model RowWidthBand {
 }
 
 model MunicipalityBand {
-  id      Int    @id @default(autoincrement())
-  sectionId Int     @map("section_id")
-  startM  Float
-  endM    Float
-  name    String
-  section Section @relation(fields: [sectionId], references: [id])
+  id        Int    @id @default(autoincrement())
+  sectionId String @map("section_id")
+  startM    Float
+  endM      Float
+  name      String
+  section   Section @relation(fields: [sectionId], references: [id])
 
   @@index([sectionId, startM, endM])
 }
 
 model BridgeBand {
-  id      Int    @id @default(autoincrement())
-  sectionId Int     @map("section_id")
-  startM  Float
-  endM    Float
-  name    String
-  section Section @relation(fields: [sectionId], references: [id])
+  id        Int    @id @default(autoincrement())
+  sectionId String @map("section_id")
+  startM    Float
+  endM      Float
+  name      String
+  section   Section @relation(fields: [sectionId], references: [id])
 
   @@index([sectionId, startM, endM])
 }
@@ -161,7 +161,7 @@ model BridgeBand {
 
 model KmPost {
   id        Int     @id @default(autoincrement())
-  sectionId Int     @map("section_id")
+  sectionId String  @map("section_id")
   chainageM Float
   lrp       String
   section   Section @relation(fields: [sectionId], references: [id])

--- a/server/server.js
+++ b/server/server.js
@@ -46,7 +46,7 @@ app.get('/api/roads', async (req, res) => {
 
 // all layers (per-band tables)
 app.get('/api/roads/:id/layers', async (req, res) => {
-  const roadId = Number(req.params.id)
+  const roadId = req.params.id
   const road = await prisma.road.findUnique({ where: { id: roadId } })
   if (!road) return res.status(404).json({ error: 'Road not found' })
   const sections = await prisma.section.findMany({ where: { roadId }, orderBy: [{ startM: 'asc' }, { id: 'asc' }] })
@@ -82,7 +82,7 @@ app.get('/api/roads/:id/layers', async (req, res) => {
  *   bridges:     { leftId?:number, rightId?:number, m:number, edge:'start'|'end' }
  */
 app.post('/api/roads/:id/bands/:band/move-seam', async (req, res) => {
-  const roadId = Number(req.params.id)
+  const roadId = req.params.id
   const band = String(req.params.band)
   const meta = BAND_META[band]
   if (!meta) return res.status(400).json({ error: 'Unknown band' })


### PR DESCRIPTION
## Summary
- store road and section identifiers as strings in Prisma schema
- handle string road ids in API endpoints
- stop casting road and section ids to numbers in client selectors

## Testing
- `npx prisma validate --schema server/prisma/schema.prisma` *(fails: Environment variable not found: DATABASE_URL)*
- `npm test` *(fails: Missing script: "test")*
- `cd client && npm test` *(fails: Missing script: "test")*
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8241c815c8323a8faa7b68f33cb70