### PR TITLE
Sort layers to keep surface band aligned with SLD

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -62,10 +62,12 @@ export default function App() {
         startKm: Math.max(r.startKm, start) - start,
         endKm: Math.min(r.endKm, end) - start,
       }))
+      .sort((a, b) => a.startKm - b.startKm)
 
     const slicePosts = (arr = []) => arr
       .filter(p => p.sectionId === section.id)
       .map(p => ({ ...p, chainageKm: p.chainageKm - start }))
+      .sort((a, b) => a.chainageKm - b.chainageKm)
 
     if (allLayers) {
       setLayers({


### PR DESCRIPTION
## Summary
- sort section layer arrays by start position so bands and SLD share the same order
- keep km post arrays sorted for consistent rendering

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a847818e5c832381a8d44309597f39