### PR TITLE
Improve zooming smoothness in SLD visualizer

### DIFF
--- a/client/src/components/SLDCanvasV2.jsx
+++ b/client/src/components/SLDCanvasV2.jsx
@@ -493,9 +493,9 @@ export default function SLDCanvasV2({
     const { xToKm } = helpersRef.current
     const { offsetX } = e.nativeEvent
     const mouseKm = xToKm(offsetX)
-    const zoomIn = e.deltaY < 0
-    const factor = zoomIn ? 0.9 : 1.1
     const currSpan = Math.max(0.001, toKm - fromKm)
+    // Use the wheel delta directly for smoother zooming instead of fixed steps.
+    const factor = Math.exp(e.deltaY * 0.001)
     let newSpan = Math.min(lengthKm, Math.max(0.05, currSpan * factor))
     const leftFrac = (mouseKm - fromKm) / currSpan
     let newFrom = mouseKm - leftFrac * newSpan


### PR DESCRIPTION
## Summary
- Use wheel delta to compute zoom factor for finer, smoother scaling in `SLDCanvasV2`

## Testing
- `npm test` (client) *(fails: Missing script "test")*
- `npm run lint` (client)
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a84a2a73d8832399c7cee9c8428187