### PR TITLE
Preserve zoom when editing seams

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -52,8 +52,6 @@ export default function App() {
     if (!section) { setLayers(null); return }
     const start = section.startKm
     const end   = section.endKm
-    const length = end - start
-    setFromKm(0); setToKm(length)
 
     const slice = (arr = []) => arr
       .filter(r => r.sectionId === section.id)
@@ -83,6 +81,15 @@ export default function App() {
       })
     }
   }, [sectionId, sectionList, allLayers])
+
+  useEffect(() => {
+    if (!sectionId) return
+    const section = sectionList.find(s => s.id === sectionId)
+    if (!section) return
+    const length = section.endKm - section.startKm
+    setFromKm(0)
+    setToKm(length)
+  }, [sectionId, sectionList])
 
   const onSearch = async () => {
     const r = await fetchRoads(q)


### PR DESCRIPTION
## Summary
- Avoid resetting zoom when layers update by removing domain changes from layer-slicing effect
- Add dedicated effect to reset domain only when section changes, keeping zoom steady during seam edits

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a850276a6c832391e3310d2a15f557