### PR TITLE
Fix line guide tooltip distance measurement

### DIFF
--- a/client/src/components/SLDCanvasV2.jsx
+++ b/client/src/components/SLDCanvasV2.jsx
@@ -52,15 +52,13 @@ function formatLRP(km, posts = []) {
   }
   const prevLrpKm = parseLrpKm(prev?.lrp)
   const nextLrpKm = parseLrpKm(next?.lrp)
-  if (prevLrpKm != null && nextLrpKm != null && prev !== next) {
-    const span = Math.max(1e-9, next.chainageKm - prev.chainageKm)
-    const t = (km - prev.chainageKm) / span
-    const interp = prevLrpKm + t * (nextLrpKm - prevLrpKm)
-    return formatLrpKm(interp)
+  if (prev.chainageKm <= km && prevLrpKm != null) {
+    const lrpKm = prevLrpKm + (km - prev.chainageKm)
+    return formatLrpKm(lrpKm)
   }
-  if (prevLrpKm != null) {
-    const interp = prevLrpKm + (km - prev.chainageKm)
-    return formatLrpKm(interp)
+  if (next.chainageKm >= km && nextLrpKm != null) {
+    const lrpKm = nextLrpKm - (next.chainageKm - km)
+    return formatLrpKm(lrpKm)
   }
   return formatLrpKm(km)
 }


### PR DESCRIPTION
## Summary
- ensure line guide tooltip measures distance from nearest kilometer post without interpolation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix client test` *(fails: Missing script "test")*
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a854cfdb1c8323b34597e4cee57fee