### PR TITLE
Hide band labels when bands too narrow

### DIFF
--- a/client/src/components/SLDCanvasV2.jsx
+++ b/client/src/components/SLDCanvasV2.jsx
@@ -351,11 +351,14 @@ export default function SLDCanvasV2({
 
         const lbl = labelFn ? labelFn(r) : ''
         if (lbl) {
-          ctx.fillStyle = '#fff'
           ctx.font = '11px system-ui'
-          ctx.textAlign = 'center'
-          ctx.fillText(lbl, x1 + ww/2, trackY + (trackH/2) + 3)
-          ctx.textAlign = 'left'
+          const textW = ctx.measureText(lbl).width
+          if (textW + 4 <= ww) {
+            ctx.fillStyle = '#fff'
+            ctx.textAlign = 'center'
+            ctx.fillText(lbl, x1 + ww / 2, trackY + (trackH / 2) + 3)
+            ctx.textAlign = 'left'
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- avoid rendering band labels when the text would overflow the band

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix client test` *(fails: Missing script: "test")*
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a883ceeaac8323be4200612b2d36d2