### PR TITLE
Prevent zoom reset when clearing line guide

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -102,13 +102,13 @@ export default function App() {
   }, [sectionId, sectionList, allLayers])
 
   useEffect(() => {
-    if (!sectionId || guideKm != null) return
+    if (!sectionId) return
     const section = sectionList.find(s => s.id === sectionId)
     if (!section) return
     const length = section.endKm - section.startKm
     setFromKm(0)
     setToKm(length)
-  }, [sectionId, sectionList, guideKm])
+  }, [sectionId, sectionList])
 
   useEffect(() => {
     if (guideKm == null) return


### PR DESCRIPTION
## Summary
- Avoid resetting zoom when clearing a line guide by running the default zoom only on section change

## Testing
- `npm test` (fails: Missing script "test")
- `cd client && npm test` (fails: Missing script "test")
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa6ba2d18883239b4ecf001e1ba238