### PR TITLE
fix: retain section when searching by km post

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -169,10 +169,11 @@ export default function App() {
   const onSearch = () => {
     const kmVal = lrpToChainageKm(q, allLayers?.kmPosts)
     if (kmVal != null) {
-      const sec = sectionList.find(s => kmVal >= s.startKm && kmVal <= s.endKm)
+      const sec = sectionList.find(s => s.id === sectionId)
       if (sec) {
-        setGuideKm(kmVal - sec.startKm)
-        setSectionId(sec.id)
+        let guide = kmVal - sec.startKm
+        guide = Math.max(0, Math.min(guide, sec.endKm - sec.startKm))
+        setGuideKm(guide)
         setShowGuide(true)
       }
       return


### PR DESCRIPTION
## Summary
- keep current section active when searching by km post
- clamp guide marker within section bounds

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abead2f7148323bc0bd5d51835dfa5