### PR TITLE
feat: embed map synced with SLD

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { fetchRoads, fetchLayers, moveBandSeam } from './api'
+import { fetchRoads, fetchLayers, moveBandSeam, fetchTrack } from './api'
 import ControlBar from './components/ControlBar'
 import SLDCanvasV2 from './components/SLDCanvasV2'
 import { DEFAULT_BAND_GROUPS, bandArrayByKey } from './bands'
 import BandAccordion, { LABEL_W } from './components/BandAccordion'
+import MapView from './components/MapView'
 import { lrpToChainageKm, formatLRP, parseLrpRange } from './lrp'
 
 const EPS = 1e-6
@@ -56,6 +57,7 @@ export default function App() {
   const [editSeams, setEditSeams] = useState(false)
 
   const [highlightRange, setHighlightRange] = useState(null)
+  const [track, setTrack] = useState([])
 
   const [bandGroups, setBandGroups] = useState(DEFAULT_BAND_GROUPS)
   const domain = useMemo(() => ({ fromKm, toKm }), [fromKm, toKm])
@@ -82,6 +84,12 @@ export default function App() {
       setSectionList(list)
       const first = list[0]
       setSectionId(first?.id || null)
+      try {
+        const t = await fetchTrack(road.id)
+        setTrack(t)
+      } catch {
+        setTrack([])
+      }
     })()
   }, [road])
 
@@ -400,8 +408,11 @@ export default function App() {
   }, [handlePanelWheel])
 
   return (
-    <div style={{ fontFamily:'Inter, system-ui, Arial', background:'#f0f2f5', minHeight:'100vh' }}>
-      <div style={{ maxWidth: 1400, margin:'0 auto', padding:'16px' }}>
+    <div style={{ fontFamily:'Inter, system-ui, Arial', background:'#f0f2f5', minHeight:'100vh', display:'flex' }}>
+      <div style={{ width:260, padding:'16px 8px' }}>
+        <MapView track={track} centerKm={(fromKm + toKm) / 2} highlightRange={highlightRange} />
+      </div>
+      <div style={{ flex:1, maxWidth: 1400, margin:'0 auto', padding:'16px' }}>
         <div style={{ display:'flex', gap:12, alignItems:'center', marginBottom:8 }}>
           <h2 style={{ margin:0 }}>Road Analyzer — SLD</h2>
           <div style={{ marginLeft:'auto', display:'flex', gap:8 }}>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -30,6 +30,11 @@ export async function fetchLayers(roadId) {
   }
 }
 
+export async function fetchTrack(roadId) {
+  const { data } = await axios.get(`${API}/api/roads/${roadId}/track`)
+  return Array.isArray(data) ? data : []
+}
+
 // ✅ Forward arbitrary extras (e.g., { edge: 'start' } for bridges)
 export async function moveBandSeam(roadId, bandKey, leftId, rightId, km, extra = {}) {
   const { data } = await axios.post(

--- a/client/src/components/MapView.jsx
+++ b/client/src/components/MapView.jsx
@@ -1,0 +1,48 @@
+import React, { useMemo } from 'react'
+
+function interp(track = [], km) {
+  if (!track.length) return null
+  let prev = track[0]
+  for (let i = 1; i < track.length; i++) {
+    const cur = track[i]
+    if (km <= cur.km) {
+      const span = cur.km - prev.km
+      const t = span > 0 ? (km - prev.km) / span : 0
+      const lat = prev.lat + t * (cur.lat - prev.lat)
+      const lng = prev.lng + t * (cur.lng - prev.lng)
+      return { lat, lng }
+    }
+    prev = cur
+  }
+  return { lat: prev.lat, lng: prev.lng }
+}
+
+export default function MapView({ track = [], centerKm, highlightRange }) {
+  const center = useMemo(() => interp(track, centerKm), [track, centerKm])
+  const span = useMemo(() => {
+    if (!highlightRange) return null
+    const start = interp(track, highlightRange.startKm)
+    const end = interp(track, highlightRange.endKm)
+    return (start && end) ? { start, end } : null
+  }, [track, highlightRange])
+
+  const src = useMemo(() => {
+    if (!center) return null
+    const zoom = 14
+    let url = `https://staticmap.openstreetmap.de/staticmap.php?center=${center.lat},${center.lng}&zoom=${zoom}&size=260x200&markers=${center.lat},${center.lng},lightblue1`
+    if (span) {
+      url += `&path=${span.start.lng},${span.start.lat}|${span.end.lng},${span.end.lat},red`
+    }
+    return url
+  }, [center, span])
+
+  return (
+    <div style={{ width: '100%', height: '100%', background: '#e0e0e0' }}>
+      {src ? (
+        <img src={src} alt="map" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+      ) : (
+        <div style={{ fontSize: 12, padding: 8 }}>No map data</div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show mini route map with center pin and optional span highlight
- fetch track coordinates and render static map synced with SLD viewport

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `cd server && npm test` (fails: Missing script: "test")
- `cd server && npm run lint` (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_68ad21a9ab248323b8c0c3c124aea284